### PR TITLE
refactor: dedupe color-by-version lookups, fix dead code and duplicate IDs

### DIFF
--- a/benches/contrast.bench.ts
+++ b/benches/contrast.bench.ts
@@ -1,7 +1,7 @@
 import { bench, describe } from "vitest";
 import {
 	relativeLuminance,
-	processColorFromHex,
+	hexToLinearRgb,
 	contrastValue,
 } from "../src/lib/functions/contrast";
 
@@ -13,16 +13,16 @@ describe("Contrast Calculation Benchmarks", () => {
 	const blue = "#0000FF";
 	const gray = "#808080";
 
-	bench("processColorFromHex - white", () => {
-		processColorFromHex(white);
+	bench("hexToLinearRgb - white", () => {
+		hexToLinearRgb(white);
 	});
 
-	bench("processColorFromHex - black", () => {
-		processColorFromHex(black);
+	bench("hexToLinearRgb - black", () => {
+		hexToLinearRgb(black);
 	});
 
-	bench("processColorFromHex - colored", () => {
-		processColorFromHex(red);
+	bench("hexToLinearRgb - colored", () => {
+		hexToLinearRgb(red);
 	});
 
 	bench("relativeLuminance calculation", () => {
@@ -38,16 +38,16 @@ describe("Contrast Calculation Benchmarks", () => {
 	});
 
 	bench("full contrast workflow - white vs black", () => {
-		const { r: r1, g: g1, b: b1 } = processColorFromHex(white);
-		const { r: r2, g: g2, b: b2 } = processColorFromHex(black);
+		const { r: r1, g: g1, b: b1 } = hexToLinearRgb(white);
+		const { r: r2, g: g2, b: b2 } = hexToLinearRgb(black);
 		const l1 = relativeLuminance(r1, g1, b1);
 		const l2 = relativeLuminance(r2, g2, b2);
 		contrastValue(l1, l2);
 	});
 
 	bench("full contrast workflow - colored", () => {
-		const { r: r1, g: g1, b: b1 } = processColorFromHex(red);
-		const { r: r2, g: g2, b: b2 } = processColorFromHex(blue);
+		const { r: r1, g: g1, b: b1 } = hexToLinearRgb(red);
+		const { r: r2, g: g2, b: b2 } = hexToLinearRgb(blue);
 		const l1 = relativeLuminance(r1, g1, b1);
 		const l2 = relativeLuminance(r2, g2, b2);
 		contrastValue(l1, l2);
@@ -57,8 +57,8 @@ describe("Contrast Calculation Benchmarks", () => {
 		const colors = [white, black, red, blue, gray];
 		for (let i = 0; i < colors.length; i++) {
 			for (let j = i + 1; j < colors.length; j++) {
-				const { r: r1, g: g1, b: b1 } = processColorFromHex(colors[i]);
-				const { r: r2, g: g2, b: b2 } = processColorFromHex(colors[j]);
+				const { r: r1, g: g1, b: b1 } = hexToLinearRgb(colors[i]);
+				const { r: r2, g: g2, b: b2 } = hexToLinearRgb(colors[j]);
 				const l1 = relativeLuminance(r1, g1, b1);
 				const l2 = relativeLuminance(r2, g2, b2);
 				contrastValue(l1, l2);

--- a/src/lib/data/color.ts
+++ b/src/lib/data/color.ts
@@ -7,7 +7,7 @@ import {
 } from "./color-tailwind";
 
 import { processColorFromHex, processColorFromOklch } from "$lib/functions/color";
-import type { Version } from "$lib/types/color";
+import type { Version } from "$lib/types/version";
 
 export const colorV4 = processColorFromOklch(tailwindColors4);
 export const colorV3 = processColorFromHex(tailwindColors3);

--- a/src/lib/data/color.ts
+++ b/src/lib/data/color.ts
@@ -7,9 +7,26 @@ import {
 } from "./color-tailwind";
 
 import { processColorFromHex, processColorFromOklch } from "$lib/functions/color";
+import type { Version } from "$lib/types/color";
 
 export const colorV4 = processColorFromOklch(tailwindColors4);
 export const colorV3 = processColorFromHex(tailwindColors3);
 export const colorV2 = processColorFromHex(tailwindColors2);
 export const colorV1 = processColorFromHex(tailwindColors1);
 export const colorV0 = processColorFromHex(tailwindColors0);
+export type ColorLists = typeof colorV4;
+
+const colorsByVersion: Record<Version, ColorLists> = {
+	V4: colorV4,
+	V3: colorV3,
+	V2: colorV2,
+	V1: colorV1,
+	V0: colorV0,
+};
+
+/** Looks up the color list for a Tailwind version, optionally dropping the black/white entries. */
+export function getColorsByVersion(version: Version, excludeGrayscale = false): ColorLists {
+	const colors = colorsByVersion[version] ?? colorV4;
+	if (!excludeGrayscale) return colors;
+	return colors.filter((color) => color.color !== "black" && color.color !== "white");
+}

--- a/src/lib/functions/contrast.ts
+++ b/src/lib/functions/contrast.ts
@@ -28,7 +28,7 @@ export function calculateRGB(color: number) {
  * @returns Object containing linearized RGB values (0-1 range)
  * @throws {Error} If the hex color format is invalid
  */
-export function hexToLinearRgb(color: string) {
+export function hexToLinearRgb(color: string): { r: number; g: number; b: number } {
 	if (!/^#[0-9A-F]{6}$/i.test(color)) {
 		throw new Error("Invalid hex color format. Expected format: #RRGGBB");
 	}

--- a/src/lib/functions/contrast.ts
+++ b/src/lib/functions/contrast.ts
@@ -28,7 +28,7 @@ export function calculateRGB(color: number) {
  * @returns Object containing linearized RGB values (0-1 range)
  * @throws {Error} If the hex color format is invalid
  */
-export function processColorFromHex(color: string) {
+export function hexToLinearRgb(color: string) {
 	if (!/^#[0-9A-F]{6}$/i.test(color)) {
 		throw new Error("Invalid hex color format. Expected format: #RRGGBB");
 	}

--- a/src/lib/types/color.ts
+++ b/src/lib/types/color.ts
@@ -1,5 +1,29 @@
+export type { TailwindColor } from "$lib/data/color-tailwind";
+export type { ColorLists } from "$lib/data/color";
+
 export type Color = "oklch" | "hex" | "hsl" | "rgb";
 export type Version = "V4" | "V3" | "V2" | "V1" | "V0";
+
+export type ColorRange = {
+	name: string;
+	shade: number;
+	oklch: {
+		long: string;
+		short: string;
+	};
+	hex: {
+		long: string;
+		short: string;
+	};
+	hsl: {
+		long: string;
+		short: string;
+	};
+	rgb: {
+		long: string;
+		short: string;
+	};
+};
 
 export type ColorOption = {
 	name: string;

--- a/src/lib/types/color.ts
+++ b/src/lib/types/color.ts
@@ -1,3 +1,5 @@
+import type { Version } from "$lib/types/version";
+
 export type { TailwindColor } from "$lib/data/color-tailwind";
 export type { ColorLists } from "$lib/data/color";
 export type { Version } from "$lib/types/version";

--- a/src/lib/types/color.ts
+++ b/src/lib/types/color.ts
@@ -1,8 +1,8 @@
 export type { TailwindColor } from "$lib/data/color-tailwind";
 export type { ColorLists } from "$lib/data/color";
+export type { Version } from "$lib/types/version";
 
 export type Color = "oklch" | "hex" | "hsl" | "rgb";
-export type Version = "V4" | "V3" | "V2" | "V1" | "V0";
 
 export type ColorRange = {
 	name: string;

--- a/src/lib/types/version.ts
+++ b/src/lib/types/version.ts
@@ -1,0 +1,1 @@
+export type Version = "V4" | "V3" | "V2" | "V1" | "V0";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,35 +7,18 @@
 	import * as Select from "$lib/components/ui/select/index.js";
 	import Toolbar from "$lib/components/toolbar.svelte";
 
-	import { colorV0, colorV1, colorV2, colorV3, colorV4 } from "$lib/data/color";
+	import { getColorsByVersion } from "$lib/data/color";
 	import { versionOptions, colorOptions } from "$lib/data/option";
-	import type { Color } from "$lib/types/color";
+	import type { Color, Version } from "$lib/types/color";
 
 	import Copy from "@lucide/svelte/icons/copy";
 	import { PersistedState } from "runed";
 	import { toast } from "svelte-sonner";
 
 	const view = new PersistedState<Color>("view", "oklch");
-	const scroll = $state({
-		y: 0,
-		x: 0,
-	});
 
-	const version = new PersistedState("version", "V4");
-	const colors = $derived.by(() => {
-		switch (version.current) {
-			case "V0":
-				return colorV0.filter((color) => color.color !== "black" && color.color !== "white");
-			case "V1":
-				return colorV1.filter((color) => color.color !== "black" && color.color !== "white");
-			case "V2":
-				return colorV2.filter((color) => color.color !== "black" && color.color !== "white");
-			case "V3":
-				return colorV3.filter((color) => color.color !== "black" && color.color !== "white");
-			default:
-				return colorV4.filter((color) => color.color !== "black" && color.color !== "white");
-		}
-	});
+	const version = new PersistedState<Version>("version", "V4");
+	const colors = $derived(getColorsByVersion(version.current, true));
 </script>
 
 <svelte:head>
@@ -45,13 +28,6 @@
 		content="Check out all available Tailwind CSS colors across different versions, from v0 to v4. Compare the old color and gradient with the new one."
 	/>
 </svelte:head>
-
-<svelte:window
-	onscroll={() => {
-		scroll.y = window.scrollY;
-		scroll.x = window.scrollX;
-	}}
-/>
 
 <div class="flex w-full flex-col gap-4">
 	<Toolbar>

--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -7,53 +7,28 @@
 	import { PersistedState } from "runed";
 	import ArrowLeftRight from "@lucide/svelte/icons/arrow-left-right";
 
-	import { colorV0, colorV1, colorV2, colorV3, colorV4 } from "$lib/data/color";
+	import { getColorsByVersion } from "$lib/data/color";
 	import { versionOptions } from "$lib/data/option";
+	import type { Version } from "$lib/types/color";
 
-	let leftVersion = new PersistedState("leftVersion", "V4");
-	const leftColorOptions = $derived.by(() => {
-		switch (leftVersion.current) {
-			case "V0":
-				return colorV0;
-			case "V1":
-				return colorV1;
-			case "V2":
-				return colorV2;
-			case "V3":
-				return colorV3;
-			default:
-				return colorV4;
-		}
-	});
-	let leftColor = new PersistedState("leftColor", "red");
+	const leftVersion = new PersistedState<Version>("leftVersion", "V4");
+	const leftColorOptions = $derived(getColorsByVersion(leftVersion.current));
+	const leftColor = new PersistedState("leftColor", "red");
 	const leftChoice = $derived(
 		leftColorOptions.find((color) => color.color === leftColor.current)?.range,
 	);
-	let leftShade = new PersistedState("leftShade", "500");
+	const leftShade = new PersistedState("leftShade", "500");
 	const leftSelectedColor = $derived(
 		leftChoice?.find((color) => color.shade.toString() === leftShade.current),
 	);
 
-	let rightVersion = new PersistedState("rightVersion", "V4");
-	const rightColorOptions = $derived.by(() => {
-		switch (rightVersion.current) {
-			case "V0":
-				return colorV0;
-			case "V1":
-				return colorV1;
-			case "V2":
-				return colorV2;
-			case "V3":
-				return colorV3;
-			default:
-				return colorV4;
-		}
-	});
-	let rightColor = new PersistedState("rightColor", "red");
+	const rightVersion = new PersistedState<Version>("rightVersion", "V4");
+	const rightColorOptions = $derived(getColorsByVersion(rightVersion.current));
+	const rightColor = new PersistedState("rightColor", "red");
 	const rightChoice = $derived(
 		rightColorOptions.find((color) => color.color === rightColor.current)?.range,
 	);
-	let rightShade = new PersistedState("rightShade", "500");
+	const rightShade = new PersistedState("rightShade", "500");
 	const rightSelectedColor = $derived(
 		rightChoice?.find((color) => color.shade.toString() === rightShade.current),
 	);

--- a/src/routes/contrast/+page.svelte
+++ b/src/routes/contrast/+page.svelte
@@ -21,10 +21,11 @@
 	import CaseLower from "@lucide/svelte/icons/case-lower";
 	import EyeOff from "@lucide/svelte/icons/eye-off";
 
-	import { colorV0, colorV1, colorV2, colorV3, colorV4 } from "$lib/data/color";
+	import { getColorsByVersion } from "$lib/data/color";
 	import { versionOptions } from "$lib/data/option";
-	import { contrastValue, processColorFromHex, relativeLuminance } from "$lib/functions/contrast";
+	import { contrastValue, hexToLinearRgb, relativeLuminance } from "$lib/functions/contrast";
 	import { cubicOut } from "svelte/easing";
+	import type { Version } from "$lib/types/color";
 
 	const minContrastSmall = 4.5;
 	const minContrastLarge = 3;
@@ -46,26 +47,12 @@
 			],
 		},
 	];
-	const version = new PersistedState("version", "V4");
-	const contrastType = new PersistedState("contrastType", "apca");
+	const version = new PersistedState<Version>("version", "V4");
+	const contrastType = new PersistedState<"wcag" | "apca">("contrastType", "apca");
 
-	const color = $derived.by(() => {
-		switch (version.current) {
-			case "V0":
-				return colorV0;
-			case "V1":
-				return colorV1;
-			case "V2":
-				return colorV2;
-			case "V3":
-				return colorV3;
-			default:
-				return colorV4;
-		}
-	});
-	const bgColorOptions = $derived(color);
+	const color = $derived(getColorsByVersion(version.current));
 	const bgColor = new PersistedState("bgColor", "white");
-	const bgChoice = $derived(bgColorOptions.find((color) => color.color === bgColor.current)?.range);
+	const bgChoice = $derived(color.find((color) => color.color === bgColor.current)?.range);
 	const bgShade = new PersistedState("bgShade", "0");
 	const bgSelectedColor = $derived(
 		bgChoice?.find((color) => color.shade.toString() === bgShade.current),
@@ -76,11 +63,8 @@
 		{ capacity: 10 },
 	);
 
-	const textColorOptions = $derived(color);
 	const textColor = new PersistedState("textColor", "black");
-	const textChoice = $derived(
-		textColorOptions.find((color) => color.color === textColor.current)?.range,
-	);
+	const textChoice = $derived(color.find((color) => color.color === textColor.current)?.range);
 	const textShade = new PersistedState("textShade", "0");
 	const textSelectedColor = $derived(
 		textChoice?.find((color) => color.shade.toString() === textShade.current),
@@ -93,9 +77,9 @@
 
 	const contrastRatio = $derived.by(() => {
 		if (!bgSelectedColor || !textSelectedColor) return 0;
-		const bgColor = processColorFromHex(bgSelectedColor.hex.long ?? "");
+		const bgColor = hexToLinearRgb(bgSelectedColor.hex.long ?? "");
 		const bgLuminance = relativeLuminance(bgColor.r, bgColor.g, bgColor.b);
-		const textColor = processColorFromHex(textSelectedColor.hex.long ?? "");
+		const textColor = hexToLinearRgb(textSelectedColor.hex.long ?? "");
 		const textLuminance = relativeLuminance(textColor.r, textColor.g, textColor.b);
 
 		return contrastValue(bgLuminance, textLuminance);
@@ -154,13 +138,13 @@
 						}}
 					>
 						<Select.Trigger id="leftColor" class="w-full capitalize" placeholder="Select Color">
-							{bgColorOptions.find((option) => option.color === bgColor.current)?.color ??
+							{color.find((option) => option.color === bgColor.current)?.color ??
 								"Select Color"}
 						</Select.Trigger>
 						<Select.Content preventScroll>
 							<Select.Group>
 								<Select.Label>Color</Select.Label>
-								{#each bgColorOptions as option (option.color)}
+								{#each color as option (option.color)}
 									<Select.Item value={option.color} class="capitalize">{option.color}</Select.Item>
 								{/each}
 							</Select.Group>
@@ -230,13 +214,13 @@
 						}}
 					>
 						<Select.Trigger id="textColor" class="w-full capitalize" placeholder="Select Color">
-							{textColorOptions.find((option) => option.color === textColor.current)?.color ??
+							{color.find((option) => option.color === textColor.current)?.color ??
 								"Select Color"}
 						</Select.Trigger>
 						<Select.Content preventScroll>
 							<Select.Group>
 								<Select.Label>Color</Select.Label>
-								{#each textColorOptions as option (option.color)}
+								{#each color as option (option.color)}
 									<Select.Item value={option.color} class="capitalize">{option.color}</Select.Item>
 								{/each}
 							</Select.Group>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -10,29 +10,16 @@
 	import { PersistedState } from "runed";
 	import { toast } from "svelte-sonner";
 
-	import { colorV0, colorV1, colorV2, colorV3, colorV4 } from "$lib/data/color";
+	import { getColorsByVersion } from "$lib/data/color";
 	import { colorOptions, versionOptions } from "$lib/data/option";
-	import type { Color } from "$lib/types/color";
+	import type { Color, Version } from "$lib/types/color";
 
 	const border = new PersistedState("border", false);
 	const gap = new PersistedState("gap", true);
-	const version = new PersistedState("version", "V4");
+	const version = new PersistedState<Version>("version", "V4");
 	const view = new PersistedState<Color>("view", "oklch");
 
-	const colors = $derived.by(() => {
-		switch (version.current) {
-			case "V0":
-				return colorV0.filter((color) => color.color !== "black" && color.color !== "white");
-			case "V1":
-				return colorV1.filter((color) => color.color !== "black" && color.color !== "white");
-			case "V2":
-				return colorV2.filter((color) => color.color !== "black" && color.color !== "white");
-			case "V3":
-				return colorV3.filter((color) => color.color !== "black" && color.color !== "white");
-			default:
-				return colorV4.filter((color) => color.color !== "black" && color.color !== "white");
-		}
-	});
+	const colors = $derived(getColorsByVersion(version.current, true));
 </script>
 
 <svelte:head>
@@ -93,7 +80,7 @@
 			class="flex h-8 items-center gap-2 rounded-md border p-2 hover:bg-accent/50 has-aria-checked:border-violet-600 has-aria-checked:bg-violet-50 dark:has-aria-checked:border-violet-900 dark:has-aria-checked:bg-violet-950"
 		>
 			<Checkbox
-				id="toggle-2"
+				id="toggle-3"
 				bind:checked={gap.current}
 				class="rounded-[3px] data-[state=checked]:border-violet-600 data-[state=checked]:bg-violet-600 data-[state=checked]:text-white dark:data-[state=checked]:border-violet-700 dark:data-[state=checked]:bg-violet-700"
 			/>

--- a/src/routes/gradient/+page.svelte
+++ b/src/routes/gradient/+page.svelte
@@ -9,59 +9,34 @@
 	import ArrowLeftRight from "@lucide/svelte/icons/arrow-left-right";
 	import { PersistedState } from "runed";
 
-	import { colorV0, colorV1, colorV2, colorV3, colorV4 } from "$lib/data/color";
+	import { getColorsByVersion } from "$lib/data/color";
 	import { interpolationOptions, versionOptions } from "$lib/data/option";
+	import type { Version } from "$lib/types/color";
 
 	const interpolation = new PersistedState("interpolation", "oklch");
-	const version = new PersistedState("version", "V4");
+	const version = new PersistedState<Version>("version", "V4");
 	const degree = new PersistedState("degree", 90);
-	const leftColorOptions = $derived.by(() => {
-		switch (version.current) {
-			case "V0":
-				return colorV0;
-			case "V1":
-				return colorV1;
-			case "V2":
-				return colorV2;
-			case "V3":
-				return colorV3;
-			default:
-				return colorV4;
-		}
-	});
-	let leftColor = new PersistedState("gradientLeftColor", "red");
+	const colorOptions = $derived(getColorsByVersion(version.current));
+
+	const leftColor = new PersistedState("gradientLeftColor", "red");
 	const leftChoice = $derived(
-		leftColorOptions.find((color) => color.color === leftColor.current)?.range,
+		colorOptions.find((color) => color.color === leftColor.current)?.range,
 	);
-	let leftShade = new PersistedState("gradientLeftShade", "500");
+	const leftShade = new PersistedState("gradientLeftShade", "500");
 	const leftSelectedColor = $derived(
 		leftChoice?.find((color) => color.shade.toString() === leftShade.current),
 	);
 
-	const rightColorOptions = $derived.by(() => {
-		switch (version.current) {
-			case "V0":
-				return colorV0;
-			case "V1":
-				return colorV1;
-			case "V2":
-				return colorV2;
-			case "V3":
-				return colorV3;
-			default:
-				return colorV4;
-		}
-	});
-	let rightColor = new PersistedState("gradientRightColor", "fuchsia");
+	const rightColor = new PersistedState("gradientRightColor", "fuchsia");
 	const rightChoice = $derived(
-		rightColorOptions.find((color) => color.color === rightColor.current)?.range,
+		colorOptions.find((color) => color.color === rightColor.current)?.range,
 	);
-	let rightShade = new PersistedState("gradientRightShade", "500");
+	const rightShade = new PersistedState("gradientRightShade", "500");
 	const rightSelectedColor = $derived(
 		rightChoice?.find((color) => color.shade.toString() === rightShade.current),
 	);
 
-	let value = new PersistedState("gradientStops", [0, 100]);
+	const value = new PersistedState("gradientStops", [0, 100]);
 </script>
 
 <svelte:head>
@@ -157,13 +132,13 @@
 								placeholder="Select Color"
 								size="sm"
 							>
-								{leftColorOptions.find((option) => option.color === leftColor.current)?.color ??
+								{colorOptions.find((option) => option.color === leftColor.current)?.color ??
 									"Select Color"}
 							</Select.Trigger>
 							<Select.Content preventScroll={false}>
 								<Select.Group>
 									<Select.Label>Color</Select.Label>
-									{#each leftColorOptions as option (option.color)}
+									{#each colorOptions as option (option.color)}
 										<Select.Item value={option.color} class="capitalize">{option.color}</Select.Item
 										>
 									{/each}
@@ -227,13 +202,13 @@
 								placeholder="Select Color"
 								size="sm"
 							>
-								{rightColorOptions.find((option) => option.color === rightColor.current)?.color ??
+								{colorOptions.find((option) => option.color === rightColor.current)?.color ??
 									"Select Color"}
 							</Select.Trigger>
 							<Select.Content preventScroll={false}>
 								<Select.Group>
 									<Select.Label>Color</Select.Label>
-									{#each rightColorOptions as option (option.color)}
+									{#each colorOptions as option (option.color)}
 										<Select.Item value={option.color} class="capitalize">{option.color}</Select.Item
 										>
 									{/each}


### PR DESCRIPTION
## Summary
- Extracted a shared `getColorsByVersion(version, excludeGrayscale?)` helper (`src/lib/data/color.ts`) to replace the identical `switch(version){case "V0": ...}` block that was copy-pasted across `+page.svelte`, `gallery`, `compare` (x2), `gradient` (x2), and `contrast`.
- Typed `PersistedState<Version>` consistently instead of leaving `version` state as bare `string`.
- Fixed a real bug: duplicate `id="toggle-2"` on the Gallery page's Border/Gap checkboxes (invalid HTML, only one had a unique id).
- Removed dead `scroll` `$state` in `+page.svelte` — it was written to on every scroll event but never read anywhere.
- Deleted `src/lib/components/card.svelte`, an empty file with no references anywhere in the codebase.
- Renamed `functions/contrast.ts`'s `processColorFromHex` to `hexToLinearRgb` — it shared a name with an unrelated `processColorFromHex` in `functions/color.ts` (different signature/purpose), which was confusing to import.
- Collapsed pointless aliases (`bgColorOptions`/`textColorOptions` in `contrast`, and gradient's duplicate `rightColorOptions`) that just re-read the exact same derived value under a different name.
- Changed `let` to `const` for `PersistedState` instances that are never reassigned.

This also carries forward pre-existing WIP (`ColorLists`/`ColorRange` type additions) that was uncommitted on `main` before this branch was cut, so it isn't lost.

No behavior change intended — all five routes (`/`, `/compare`, `/contrast`, `/gallery`, `/gradient`) were built and smoke-tested via `vite preview` (200 on all).

## Test plan
- [x] `pnpm build` succeeds
- [x] `vite preview` smoke test: all 5 routes return 200
- [ ] `pnpm check` / `pnpm lint` — currently broken on this repo's `main` too (pre-existing `typescript@^7.0.2` incompatibility with `svelte-check`/`typescript-eslint`, verified by stashing changes and reproducing the same crash on unmodified code)
- [ ] Manual click-through in a browser (recommend before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version-aware color selection across the color, comparison, contrast, gallery, and gradient tools.
  - Added an option to exclude black and white from color lists.
  - Improved color and version selection consistency across the app.

- **Bug Fixes**
  - Fixed duplicate element identifiers in the gallery.
  - Improved contrast color processing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->