### PR TITLE
fix(nav,gallery): mobile theme/github access + gallery header squeeze

### DIFF
--- a/src/lib/components/nav.svelte
+++ b/src/lib/components/nav.svelte
@@ -43,6 +43,51 @@
 				{item.name}
 			</a>
 		{/each}
+		<div class="mt-2 flex items-center justify-end gap-2 border-t pt-4 sm:hidden">
+			<Button
+				variant="ghost"
+				size="icon"
+				class="dark:fill-white"
+				href="https://github.com/RMalik777/Tailwind-Color"
+				target="_blank"
+				rel="noopener noreferrer"
+				onclick={() => (open = false)}
+			>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html siGithub.svg}
+			</Button>
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger class={buttonVariants({ variant: "outline", size: "icon" })}>
+					<SunIcon
+						class="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all! dark:scale-0 dark:-rotate-90"
+					/>
+					<MoonIcon
+						class="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all! dark:scale-100 dark:rotate-0"
+					/>
+					<span class="sr-only">Toggle theme</span>
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="end">
+					<DropdownMenu.Item
+						onclick={() => {
+							setMode("light");
+							open = false;
+						}}>Light</DropdownMenu.Item
+					>
+					<DropdownMenu.Item
+						onclick={() => {
+							setMode("dark");
+							open = false;
+						}}>Dark</DropdownMenu.Item
+					>
+					<DropdownMenu.Item
+						onclick={() => {
+							resetMode();
+							open = false;
+						}}>System</DropdownMenu.Item
+					>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</div>
 	</div>
 	<div class="hidden items-center justify-end space-x-1 sm:flex">
 		<Button

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -89,14 +89,18 @@
 	</Toolbar>
 
 	<div
-		class="flex h-full w-full flex-row duration-150 ease-out {gap.current
+		class="flex h-full w-full flex-row overflow-x-auto duration-150 ease-out {gap.current
 			? 'gap-0.5 sm:gap-1'
 			: 'gap-0'}"
 	>
 		{#each colors as color (color.color)}
-			<div animate:flip={{ duration: 200, easing: quintOut }} class="flex w-full grow flex-col">
+			<div
+				animate:flip={{ duration: 200, easing: quintOut }}
+				class="flex min-w-10 shrink-0 grow flex-col"
+			>
 				<div class="relative h-6 w-full">
 					<p
+						title={color.color}
 						class="absolute top-0 right-0 w-full truncate text-center text-xs text-muted-foreground capitalize sm:text-sm"
 					>
 						{color.color}


### PR DESCRIPTION
## Summary
- Mobile nav dropdown was missing the theme toggle and GitHub link entirely (the desktop-only container was `hidden` below `sm`, with no mobile fallback) — phone users had no way to switch theme or reach the repo. Added both into the mobile panel, closing it on selection.
- Gallery grid squeezed all 26 color columns to fit any viewport width with no minimum, so headers collapsed to single letters on tablet/phone. Columns now keep a `min-w-10` floor and the row scrolls horizontally instead; desktop layout is visually unchanged (still no scrollbar at typical widths). Added a `title` attribute as a hover fallback for the still-truncated desktop labels.

Found during a manual design/accessibility review (desktop/tablet/mobile viewports, light/dark theme, keyboard nav).

## Test plan
- [x] Verified mobile (375px): hamburger menu now shows GitHub + theme toggle below the nav links; dropdown opens un-clipped, selecting a theme applies it and closes the menu.
- [x] Verified desktop (1280px) nav is pixel-unchanged (icons only in top-right, no duplication).
- [x] Verified Gallery at 1280px: no scrollbar, grid visually identical to before.
- [x] Verified Gallery at 768px/375px: full/near-full color names readable, horizontal scroll reveals remaining columns, no page-level overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation behavior by ensuring GitHub and theme controls appear correctly in the mobile menu.
  * Selecting a theme now automatically closes the mobile navigation menu.

* **UI Improvements**
  * Enhanced gallery layout stability and enabled horizontal scrolling for narrower screens.
  * Preserved existing color display, copy-to-clipboard, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->